### PR TITLE
Fixed wrong link in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NERC Documentation
 
 User-facing documentation for the New England Research Cloud
-This repository contains NERC [documentation](https://docs.nerc.mghpcc.org/) written
+This repository contains NERC [documentation](https://nerc-project.github.io/nerc-docs/) written
 in Markdown which is converted to html/css/js with the
 [mkdocs](http://www.mkdocs.org) static site generator. The theme is [mkdocs-material](https://github.com/squidfunk/mkdocs-material)
 with NERC custom theme and template. The documentation pages can be found in


### PR DESCRIPTION
Link points to docs.nerc.mghpcc.org which doesn't currently work.