### PR TITLE
added ocp upgrade info

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -38,14 +38,14 @@ footer .footer-center {
 
 .parent {
   /* background: #CCCCCC; */
-  height: 55px;
+  height: 110px;
   /* width: 200px; */
   position: relative;
   }
 
   .maintain{
     position: absolute;
-    top: 20%;
+    top: 5%;
     /* left: 50%; */
     /* margin: -25px 0 0 -35px; */
   }

--- a/nerc-theme/main.html
+++ b/nerc-theme/main.html
@@ -9,6 +9,12 @@
         href="https://nerc.mghpcc.org/events/nerc-maintenace-september-18-2023/"
         target="_blank">[Timeline and info]</a>
     </div>
+    <div>Upcoming Red Hat's OpenShift Cluster Platform (OCP) Version Upgrade</div>
+    <div>on NERC [September 27, 2023 8:00 AM -5:00 PM]
+      <a style="color: #00efff;"
+        href="https://nerc.mghpcc.org/events/nerc-ocp-version-upgrade-september-27-2023/"
+        target="_blank">[Timeline and info]</a>
+    </div>
   </div>
   <div class="child">
     <iframe src="https://nerc.instatus.com/embed-status/light-sm" width="230" height="52" frameBorder="0" scrolling="no" style="border: none;" ></iframe>


### PR DESCRIPTION
Upcoming Red Hat's [OpenShift container platform (OCP)](https://nerc-project.github.io/nerc-docs/openshift/) upgrade on NERC from version 4.10 to 4.13 will occur on Wednesday September 27, 2023 from 8:00 AM – 5:00 PM.