### PR TITLE
fix typo in PR 230

### DIFF
--- a/nerc-theme/main.html
+++ b/nerc-theme/main.html
@@ -1,5 +1,5 @@
-<!--
 {% extends "base.html" %} {% block announce %}
+<!--
 <div class="parent">
     <div class="maintain">
         <div>Upcoming NERC Network Equipment and Switch Maintenance</div>


### PR DESCRIPTION
PR #230 attempted to remove the maintenance banner but accidentally commented out the {% extends "base.html" %} which causes the site theme not to render correctly.