### PR TITLE
Added feature to fetch pricing info from `nerc_rates`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Build and Deploy Documentation using MkDocs
 # Controls when the action will run. Triggers the workflow on push events on main branch
 # but pull request events on any branch but deployement happens only for the main branch
 on:
+    schedule:
+        - cron: '0 0 * * *' # Runs at 00:00 UTC every day
     push:
         branches: [main]
     pull_request:
@@ -35,6 +37,9 @@ jobs:
                   python -m pip install --upgrade pip
                   if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
                   git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+            - name: Fetch nerc_rates and render Jinja templates
+              run: |
+                  python scripts/add_nerc_rates.py
             - name: Clean Build
               run: |
                   mkdocs build --clean
@@ -64,6 +69,9 @@ jobs:
                   python -m pip install --upgrade pip
                   if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
                   git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+            - name: Fetch nerc_rates and render Jinja templates
+              run: |
+                  python scripts/add_nerc_rates.py
             - name: Deploy
               run: |
                   mkdocs gh-deploy --force

--- a/docs/get-started/cost-billing/how-pricing-works.md
+++ b/docs/get-started/cost-billing/how-pricing-works.md
@@ -29,15 +29,16 @@ and billing model.
 ## Calculations
 
 ### Service Units (SUs)
-
+<!-- markdownlint-disable MD052 -->
 | Name         | vGPU | vCPU | RAM (GiB) | Current Price |
 | ------------ | ---- | ---- | --------- | ------------- |
-| H100 GPU     | 1    | 63   | 376       | $6.04         |
-| A100sxm4 GPU | 1    | 31   | 240       | $2.078        |
-| A100 GPU     | 1    | 24   | 74        | $1.803        |
-| V100 GPU     | 1    | 48   | 192       | $1.214        |
-| K80 GPU      | 1    | 6    | 28.5      | $0.463        |
-| CPU          | 0    | 1    | 4         | $0.013        |
+| H100 GPU     | {{su_info_dict["GPUH100"]["vGPUs"]}}    | {{su_info_dict["GPUH100"]["vCPUs"]}}   | {{su_info_dict["GPUH100"]["RAM"]}}       | ${{su_info_dict["GPUH100"]["rate"]}}        |
+| A100sxm4 GPU | {{su_info_dict["GPUA100SXM4"]["vGPUs"]}}    | {{su_info_dict["GPUA100SXM4"]["vCPUs"]}}   | {{su_info_dict["GPUA100SXM4"]["RAM"]}}       | ${{su_info_dict["GPUA100SXM4"]["rate"]}}        |
+| A100 GPU     | {{su_info_dict["GPUA100"]["vGPUs"]}}    | {{su_info_dict["GPUA100"]["vCPUs"]}}   | {{su_info_dict["GPUA100"]["RAM"]}}       | ${{su_info_dict["GPUA100"]["rate"]}}        |
+| V100 GPU     | {{su_info_dict["GPUV100"]["vGPUs"]}}    | {{su_info_dict["GPUV100"]["vCPUs"]}}   | {{su_info_dict["GPUV100"]["RAM"]}}       | ${{su_info_dict["GPUV100"]["rate"]}}        |
+| K80 GPU      | {{su_info_dict["GPUK80"]["vGPUs"]}}    | {{su_info_dict["GPUK80"]["vCPUs"]}}   | {{su_info_dict["GPUK80"]["RAM"]}}       | ${{su_info_dict["GPUK80"]["rate"]}}        |
+| CPU          | {{su_info_dict["CPU"]["vGPUs"]}}    | {{su_info_dict["CPU"]["vCPUs"]}}   | {{su_info_dict["CPU"]["RAM"]}}       | ${{su_info_dict["CPU"]["rate"]}}        |
+<!-- markdownlint-enable MD052 -->
 
 !!! info "Expected Availability of H100 GPUs"
 
@@ -52,6 +53,7 @@ Pods (summed up by Project) and VMs on a per-hour basis for any portion of an
 hour they are used, and any VM "flavor"/Pod reservation is charged as a multiplier
 of the base SU for the maximum resource they reserve.
 
+<!-- markdownlint-disable MD052 -->
 **GPU SU Example:**
 
 -   A Project or VM with:
@@ -60,9 +62,9 @@ of the base SU for the maximum resource they reserve.
 
 -   Will be charged:
 
-    `1 A100 GPU SUs x 200hrs (199.2 rounded up) x $1.803`
+    `1 A100 GPU SUs x 200hrs (199.2 rounded up) x ${{su_info_dict["GPUA100"]["rate"]}}`
 
-    `$360.60`
+    `${{ "{:,.2f}".format(su_info_dict["GPUA100"]["rate"] * 200) }}`
 
 **OpenStack CPU SU Example:**
 
@@ -72,9 +74,10 @@ of the base SU for the maximum resource they reserve.
 
 -   Will be charged:
 
-    `5 CPU SUs due to the extra RAM (20GiB vs. 12GiB(3 x 4GiB)) x 720hrs x $0.013`
+    `5 CPU SUs due to the extra RAM (20GiB vs. 12GiB(3 x 4GiB)) x 720hrs x ${{su_info_dict["CPU"]["rate"]}}`
 
-    `$46.80`
+    `${{ "{:,.2f}".format(su_info_dict["CPU"]["rate"] * 5 * 720) }}`
+<!-- markdownlint-enable MD052 -->
 
 !!! warning "Are VMs invoiced even when shut down?"
 
@@ -99,21 +102,23 @@ of the base SU for the maximum resource they reserve.
 
     iii. `2 vCPU, 4 GiB RAM, 720hrs (24hr*30days)`
 
+<!-- markdownlint-disable MD052 MD013 -->
 -   Project Will be charged:
 
     `RoundUP(Sum(`
 
-    `1 CPU SUs due to first pod * 720hrs * $0.013`
+    `1 CPU SUs due to first pod * 720hrs * ${{su_info_dict["CPU"]["rate"]}}`
 
-    `2 CPU SUs due to extra RAM (8GiB vs 0.4GiB(0.1*4GiB)) * 720hrs * $0.013`
+    `2 CPU SUs due to extra RAM (8GiB vs 0.4GiB(0.1*4GiB)) * 720hrs * ${{su_info_dict["CPU"]["rate"]}}`
 
-    `2 CPU SUs due to more CPU (2vCPU vs 1vCPU(4GiB/4)) * 720hrs * $0.013`
+    `2 CPU SUs due to more CPU (2vCPU vs 1vCPU(4GiB/4)) * 720hrs * ${{su_info_dict["CPU"]["rate"]}}`
 
     `))`
 
-    `=RoundUP(Sum(720(1+2+2)))*0.013`
+    `=RoundUP(Sum(720(1+2+2)))*{{su_info_dict["CPU"]["rate"]}}`
 
-    `$46.80`
+    `${{ "{:,.2f}".format(su_info_dict["CPU"]["rate"] * 720 * (1 + 2 + 2)) }}`
+<!-- markdownlint-enable MD052 MD013 -->
 
 !!! note "How to calculate cost for all running OpenShift pods?"
 
@@ -128,7 +133,9 @@ GPU pods, as GPU pods cannot currently share resources with CPU pods.
 
 ### Storage
 
-Storage is charged separately at a rate of **$0.009 TiB/hr** or **$9.00E-6 GiB/hr**.
+<!-- markdownlint-disable MD052 MD013 -->
+Storage is charged separately at a rate of **${{su_info_dict["Storage GB Rate"]["rate"]}} TiB/hr**
+<!-- markdownlint-enable MD052 MD013 -->
 OpenStack volumes remain provisioned until they are deleted. VM's reserve
 volumes, and you can also create extra volumes yourself. In OpenShift pods, storage
 is only provisioned while it is active, and in persistent volumes, storage remains
@@ -159,6 +166,7 @@ provisioned until it is deleted.
     allocations and [this guide](../allocation/allocation-change-request.md#request-change-resource-allocation-attributes-for-openshift-project)
     for NERC-OCP (OpenShift) allocations.
 
+<!-- markdownlint-disable MD052 MD013 -->
 **Storage Example 1:**
 
 -   Volume or VM with:
@@ -167,9 +175,9 @@ provisioned until it is deleted.
 
 -   Will be charged:
 
-    `.5 Storage TiB SU (.5 TiB x 700hrs) x $0.009 TiB/hr`
+    `.5 Storage TiB SU (.5 TiB x 700hrs) x ${{su_info_dict["Storage GB Rate"]["rate"]}} TiB/hr`
 
-    `$3.15`
+    `${{ "{:,.2f}".format(su_info_dict["Storage GB Rate"]["rate"] * 700 / 2) }}`
 
 **Storage Example 2:**
 
@@ -179,9 +187,10 @@ provisioned until it is deleted.
 
 -   Will be charged:
 
-    `10 Storage TiB SU (10TiB x 720 hrs) x $0.009 TiB/hr`
+    `10 Storage TiB SU (10TiB x 720 hrs) x ${{su_info_dict["Storage GB Rate"]["rate"]}} TiB/hr`
 
-    `$64.80`
+    `${{ "{:,.2f}".format(su_info_dict["Storage GB Rate"]["rate"] * 10 * 720) }}`
+<!-- markdownlint-enable MD052 MD013 -->
 
 Storage includes all types of storage Object, Block, Ephemeral & Image.
 

--- a/docs/get-started/cost-billing/pricing-for-bare-metal-machines.md
+++ b/docs/get-started/cost-billing/pricing-for-bare-metal-machines.md
@@ -16,12 +16,14 @@ Bare metal instances pricing is currently available as a limited offering.
 
 ## Bare Metal Pricing Calculations
 
+<!-- markdownlint-disable MD052 -->
 | Name             | vGPU | vCPU | RAM (GiB) | Current Price |
 |------------------|------|------|-----------|---------------|
-| H100 GPU         | 4    | 256  | 1,536     | $24.16        |
-| A100sxm4 GPU     | 4    | 128  | 1,024     | $8.312        |
-| FC830            | 0    | 176  | 2,048     | $3.97         |
-| FC430            | 0    | 40   | 128       | $0.75         |
+| H100 GPU         | {{su_info_dict["BM GPUH100"]["vGPUs"]}}    | {{su_info_dict["BM GPUH100"]["vCPUs"]}}   | {{su_info_dict["BM GPUH100"]["RAM"]}}       | ${{su_info_dict["BM GPUH100"]["rate"]}}        |
+| A100sxm4 GPU     | {{su_info_dict["BM GPUA100SXM4"]["vGPUs"]}}    | {{su_info_dict["BM GPUA100SXM4"]["vCPUs"]}}   | {{su_info_dict["BM GPUA100SXM4"]["RAM"]}}       | ${{su_info_dict["BM GPUA100SXM4"]["rate"]}}        |
+| FC830            | {{su_info_dict["BM FC830"]["vGPUs"]}}    | {{su_info_dict["BM FC830"]["vCPUs"]}}   | {{su_info_dict["BM FC830"]["RAM"]}}       | ${{su_info_dict["BM FC830"]["rate"]}}        |
+| FC430            | {{su_info_dict["BM FC430"]["vGPUs"]}}    | {{su_info_dict["BM FC430"]["vCPUs"]}}   | {{su_info_dict["BM FC430"]["RAM"]}}       | ${{su_info_dict["BM FC430"]["rate"]}}        |
+<!-- markdownlint-enable MD052 -->
 
 !!! info "How to request Bare Metal Machines?"
 
@@ -56,14 +58,22 @@ Bare metal instances pricing is currently available as a limited offering.
 
 -   Will be charged:
 
-    `1 H100 SU * 720hrs * $24.16 = $17,395.20`
+<!-- markdownlint-disable MD052 -->
+    {% set h100_cost = su_info_dict["BM GPUH100"]["rate"] * 720 * 1 %}
+    {% set a100sxm_cost = su_info_dict["BM GPUA100SXM4"]["rate"] * 720 * 1 %}
+    {% set fc830_cost = su_info_dict["BM FC830"]["rate"] * 720 * 2 %}
+    {% set fc430_cost = su_info_dict["BM FC430"]["rate"] * 720 * 3 %}
+    {% set cost_sum = h100_cost + a100sxm_cost + fc830_cost + fc430_cost %}
 
-    `1 A100SXM4 * 720hrs * $8.312 = $5,984.64`
+    `1 H100 SU * 720hrs * $24.16 = ${{ "{:,.2f}".format(h100_cost) }}`
 
-    `2 FC830 SU * 720hrs * $3.97 = $5,716.80`
+    `1 A100SXM4 * 720hrs * $8.312 = ${{  "{:,.2f}".format(a100sxm_cost)}}`
 
-    `3 FC430 SU * 720hrs * $0.75 = $1,620.00`
+    `2 FC830 SU * 720hrs * $3.97 = ${{ "{:,.2f}".format(fc830_cost) }}`
 
-    **Total charge** = `$30,716.64`
+    `3 FC430 SU * 720hrs * $0.75 = ${{ "{:,.2f}".format(fc430_cost) }}`
+
+    **Total charge** = `${{ "{:,.2f}".format(cost_sum) }}`
+<!-- markdownlint-enable MD052 -->
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ mkdocs==1.6.0
 mkdocs-material==9.5.30
 mkdocs-material-extensions==1.3.1
 pre-commit==3.8.0
+Jinja2>=3.1,<3.2
+git+https://github.com/CCI-MOC/nerc-rates@main#egg=nerc_rates

--- a/scripts/add_nerc_rates.py
+++ b/scripts/add_nerc_rates.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from decimal import Decimal
+
+from jinja2 import Environment, FileSystemLoader
+
+from nerc_rates import load_from_url
+
+MiB_IN_GiB = GiB_in_TiB = 1024
+
+SU_TYPE_LIST = [
+    "CPU",
+    "GPUA100",
+    "GPUA100SXM4",
+    "GPUV100",
+    "GPUK80",
+    "GPUH100",
+    "BM FC430",
+    "BM FC830",
+    "BM GPUA100SXM4",
+    "BM GPUH100",
+]
+
+SU_RESOURCETYPE_LIST = ["vCPUs", "vGPUs", "RAM"]
+
+STORAGE_NAME = "Storage GB Rate"
+
+TEMPLATE_FILE_LIST = [
+    "docs/get-started/cost-billing/how-pricing-works.md",
+    "docs/get-started/cost-billing/pricing-for-bare-metal-machines.md",
+]
+
+
+def get_current_month():
+    return datetime.now().strftime("%Y-%m")
+
+
+if __name__ == "__main__":
+    env = Environment(loader=FileSystemLoader("."))
+    rates_info = load_from_url()
+
+    su_info_dict = {}
+    for su_type in SU_TYPE_LIST:
+        su_info_dict[su_type] = {}
+        su_info_dict[su_type]["rate"] = Decimal(
+            rates_info.get_value_at(f"{su_type} SU Rate", get_current_month())
+        )
+        for su_resourcetype in SU_RESOURCETYPE_LIST:
+            su_resource_info = rates_info.get_value_at(
+                f"{su_resourcetype} in {su_type} SU", get_current_month()
+            )
+            if su_resourcetype == "RAM":
+                su_resource_info = Decimal(su_resource_info) / MiB_IN_GiB
+            su_info_dict[su_type][su_resourcetype] = su_resource_info
+
+    storage_rate = Decimal(rates_info.get_value_at(STORAGE_NAME, get_current_month()))
+    storage_rate = (storage_rate * Decimal(GiB_in_TiB)).quantize(
+        Decimal("0.001"), rounding="ROUND_UP"
+    )  # Storage rates ar only shown in TiB in the docs
+    su_info_dict[STORAGE_NAME] = {}
+    su_info_dict[STORAGE_NAME]["rate"] = storage_rate
+
+    for template_file in TEMPLATE_FILE_LIST:
+        template = env.get_template(template_file)
+        output = template.render(su_info_dict=su_info_dict)
+        with open(template_file, "w") as f:
+            f.write(output)


### PR DESCRIPTION
Closes #247. Jinja templating has been added to two pricing pages. A Python script has been created to fetch `nerc_rates` and render the templates. The ci file to publish the site has been modified accordingly.

This is a draft for now, since I'm sure there will be plenty of comments on how this code/process should be organized. I only submitted a proof-of-concept with only some of the pricing values in the markdown pages replaced with Jinja templating.
I also have the following questions:
- [ ] What version of Jinja2 should we pin?
- [ ] Since we're now fetching from `nerc_rates`, will this change when the ci workflow gets ran? Everytime a PR is pushed to `nerc_rates`?
- [ ] How should the markdown linting be modified, assuming we're fine with Jinja templating?